### PR TITLE
Add support for timeout in RelayNode and make easier to use classes with a i2c PortExpander

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "Homie node collection",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": "iot, home, automation, Arduino, esp8266, homie, sensor, relay, switch",
   "description": "Collection of Node implementations for the Homie-ESP8266 library. They implement the Homie 2.0 convention",
   "homepage": "https://github.com/bertmelis/VitoWiFi",

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Homie node collection
+version=1.0.2
+author=Lübbe Onken
+maintainer=Lübbe Onken
+sentence=Collection of Node implementations for the Homie-ESP8266 library. They implement the Homie 2.0 convention
+paragraph=Like this project? Please star it on GitHub!
+category=Device Control
+url=https://github.com/luebbe/homie-node-collection
+architectures=esp8266

--- a/src/ContactNode.cpp
+++ b/src/ContactNode.cpp
@@ -17,10 +17,20 @@ ContactNode::ContactNode(const char *name,
   _contactCallback = contactCallback;
 }
 
+int ContactNode::getContactPin() 
+{
+  return _contactPin;
+}
+
+byte ContactNode::readPin() 
+{
+  return digitalRead(_contactPin);
+}
+
 // Debounce input pin.
 bool ContactNode::debouncePin(void)
 {
-  byte inputState = digitalRead(_contactPin);
+  byte inputState = readPin();
   if (inputState != _lastInputState)
   {
     _stateChangedTime = millis();
@@ -79,6 +89,11 @@ void ContactNode::loop()
   }
 }
 
+void ContactNode::setupPin()
+{
+  pinMode(_contactPin, INPUT_PULLUP);
+}
+
 void ContactNode::setup()
 {
   advertise("open");
@@ -88,6 +103,6 @@ void ContactNode::setup()
 
   if (_contactPin > DEFAULTPIN)
   {
-    pinMode(_contactPin, INPUT_PULLUP);
+    setupPin();
   }
 }

--- a/src/ContactNode.hpp
+++ b/src/ContactNode.hpp
@@ -34,8 +34,11 @@ private:
   void printCaption();
 
 protected:
+  int getContactPin();
   virtual void loop() override;
   virtual void setup() override;
+  virtual void setupPin();
+  virtual byte readPin();
 
 public:
   ContactNode(const char *name, const int contactPin = DEFAULTPIN, TContactCallback contactCallback = NULL);

--- a/src/RelayNode.hpp
+++ b/src/RelayNode.hpp
@@ -25,11 +25,20 @@ private:
   void setLed(bool on);
 
 protected:
+  int getRelayPin();
+  long timeout;
   virtual void setup() override;
+  virtual void loop() override;
   virtual bool handleInput(const String &property, const HomieRange &range, const String &value) override;
+  virtual void setRelayState(bool on);
+  virtual bool readRelayState();
+  virtual void setupRelay();
+  void setRelay(bool on, long timeoutSecs);
 
 public:
   RelayNode(const char *name, const int relayPin = DEFAULTPIN, const int ledPin = DEFAULTPIN);
   void setRelay(bool on);
   void toggleRelay();
 };
+
+void relayBeforeHomieSetup();


### PR DESCRIPTION
add support for timeout in RelayNodes

refactor Relay and Contact Nodes, separing the physical pin access and make possible to use extend this classes to use with i2c portexpanders.
