### PR TITLE
allow to set minimum button down time

### DIFF
--- a/src/ButtonNode.cpp
+++ b/src/ButtonNode.cpp
@@ -34,6 +34,11 @@ void ButtonNode::onPress(TButtonCallback buttonCallback)
   _buttonCallback = buttonCallback;
 }
 
+void ButtonNode::setMinButtonDownTime(unsigned short downTime)
+{
+  _minButtonDownTime = downTime;
+}
+
 void ButtonNode::printCaption()
 {
   Homie.getLogger() << cCaption << endl;
@@ -59,7 +64,7 @@ void ButtonNode::loop()
       else
       {
         unsigned long dt = millis() - _buttonDownTime;
-        if (dt >= 90 && dt <= 900 && !_buttonPressHandled)
+        if (dt >= _minButtonDownTime && dt <= 900 && !_buttonPressHandled)
         {
           handleButtonPress(dt);
           _buttonPressHandled = true;

--- a/src/ButtonNode.hpp
+++ b/src/ButtonNode.hpp
@@ -26,6 +26,7 @@ private:
   byte _lastButtonState = HIGH;
   bool _buttonPressHandled = 0;
   unsigned long _buttonDownTime = 0;
+  unsigned short _minButtonDownTime = 90;
 
   void handleButtonPress(unsigned long dt);
   void printCaption();
@@ -37,4 +38,5 @@ protected:
 public:
   explicit ButtonNode(const char *name, const int buttonPin = DEFAULTPIN, TButtonCallback buttonCallback = NULL);
   void onPress(TButtonCallback buttonCallback);
+  void setMinButtonDownTime(unsigned short downTime);
 };


### PR DESCRIPTION
I tried to used smaller button down times as Sonoff 4CH Pro companion chip STM32 normally sends button presses for 75ms but this may result then in wrong interpreted RF signals. Unfortunately this could only be fixed either on the RF or the receiving STM32.