### PR TITLE
Pingnode

### DIFF
--- a/src/PingNode.cpp
+++ b/src/PingNode.cpp
@@ -85,7 +85,8 @@ void PingNode::loop()
         changed = signalChange(_distance, _lastDistance);
         if (changed)
         {
-          if (onChange(_distance, _lastDistance)) {
+          if (onChange(_distance, _lastDistance))
+          {
             _changeHandler();
           }
           _lastDistance = _distance;
@@ -98,7 +99,12 @@ void PingNode::loop()
     {
       if (_distance > 0)
       {
+        changed = signalChange(_distance, _lastPublishedDistance);
         send(changed);
+        if (changed)
+        {
+          _lastPublishedDistance = _distance;
+        }
         _lastPublish = millis();
       }
     }
@@ -182,4 +188,3 @@ PingNode &PingNode::setMaximumDistance(float maximumDistance)
   _maxDistance = maximumDistance;
   return *this;
 }
-

--- a/src/PingNode.cpp
+++ b/src/PingNode.cpp
@@ -135,7 +135,7 @@ PingNode &PingNode::setTemperature(float temperatureCelcius)
                     << "SpeedOfSound: " << soundSpeed << " " << cUnitMetersPerSecond
                     << " at " << temperatureCelcius << " " << cUnitDegrees << endl;
   // Calculating the distance from d = t_ping /2 * c => t_ping /2 * 337 [m/s] => t_ping_us / 1e-6 * 1/2 * 337
-  setMicrosecondsToMeters(0.5e-6 * soundSpeed);
+  setMicrosecondsToMeter(0.5e-6 * soundSpeed);
   return *this;
 }
 

--- a/src/PingNode.cpp
+++ b/src/PingNode.cpp
@@ -50,12 +50,12 @@ void PingNode::printCaption()
 
 void PingNode::send(bool changed)
 {
+  bool valid = _distance > 0;
   printCaption();
   Homie.getLogger() << cIndent << "Ping: " << _ping_us << " " << cUnitMicrosecond << endl;
   Homie.getLogger() << cIndent << "Distance: " << _distance << " " << cUnitMeter << endl;
-  bool valid = _distance > 0;
   Homie.getLogger() << cIndent << "Valid: " << (valid ? "ok" : "error") << endl;
-  // Homie.getLogger() << cIndent << "Changed: " << (changed ? "true" : "false") << " " << endl;
+  Homie.getLogger() << cIndent << "Changed: " << (changed ? "true" : "false") << " " << endl;
   if (Homie.isConnected())
   {
     setProperty(cValidTopic).send(valid ? "ok" : "error");

--- a/src/PingNode.cpp
+++ b/src/PingNode.cpp
@@ -85,8 +85,10 @@ void PingNode::loop()
         changed = signalChange(_distance, _lastDistance);
         if (changed)
         {
+          if (onChange(_distance, _lastDistance)) {
+            _changeHandler();
+          }
           _lastDistance = _distance;
-          _changeHandler(*this);
         }
       }
       _lastMeasurement = millis();
@@ -127,11 +129,11 @@ PingNode &PingNode::setTemperature(float temperatureCelcius)
                     << "SpeedOfSound: " << soundSpeed << " " << cUnitMetersPerSecond
                     << " at " << temperatureCelcius << " " << cUnitDegrees << endl;
   // Calculating the distance from d = t_ping /2 * c => t_ping /2 * 337 [m/s] => t_ping_us / 1e-6 * 1/2 * 337
-  setMicrosecondsToMetersFactor(0.5e-6 * soundSpeed);
+  setMicrosecondsToMeters(0.5e-6 * soundSpeed);
   return *this;
 }
 
-PingNode &PingNode::setMicrosecondsToMetersFactor(float microseconds2meter)
+PingNode &PingNode::setMicrosecondsToMeters(float microseconds2meter)
 {
   _microseconds2meter = microseconds2meter;
   return *this;

--- a/src/PingNode.cpp
+++ b/src/PingNode.cpp
@@ -14,9 +14,9 @@ bool checkBounds(float value, float min, float max)
   return !isnan(value) && value >= min && value <= max;
 }
 
-PingNode::PingNode(const char *name, const int triggerPin, const int echoPin,
+PingNode::PingNode(const char *name, const char *type, const int triggerPin, const int echoPin,
                    const int measurementInterval, const int publishInterval)
-    : SensorNode(name, "RCW-0001"),
+    : SensorNode(name, type),
       _triggerPin(triggerPin), _echoPin(echoPin), _lastMeasurement(0), _lastPublish(0)
 {
   _measurementInterval = (measurementInterval > MIN_INTERVAL) ? measurementInterval : MIN_INTERVAL;
@@ -45,7 +45,7 @@ PingNode::PingNode(const char *name, const int triggerPin, const int echoPin,
 
 void PingNode::printCaption()
 {
-  Homie.getLogger() << cCaption << " triggerpin[" << _triggerPin << "], echopin[" << _echoPin << "]:" << endl;
+  Homie.getLogger() << cCaption << getType() << " sensor triggerpin[" << _triggerPin << "], echopin[" << _echoPin << "]:" << endl;
 }
 
 void PingNode::send(bool changed)
@@ -139,7 +139,7 @@ PingNode &PingNode::setTemperature(float temperatureCelcius)
   return *this;
 }
 
-PingNode &PingNode::setMicrosecondsToMeters(float microseconds2meter)
+PingNode &PingNode::setMicrosecondsToMeter(float microseconds2meter)
 {
   _microseconds2meter = microseconds2meter;
   return *this;

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -18,7 +18,7 @@
 class PingNode : public SensorNode
 {
 public:
-  typedef std::function<void(PingNode &)> ChangeHandler;
+  typedef std::function<void()> ChangeHandler;
 
 private:
   static const int MIN_INTERVAL = 1; // in seconds

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -22,7 +22,7 @@ public:
 
 private:
   static const int MIN_INTERVAL = 1; // in seconds
-  const char *cCaption = "• RCW-0001 sensor";
+  const char *cCaption = "• ";
   const char *cIndent = "  ◦ ";
 
   int _triggerPin;
@@ -52,24 +52,26 @@ protected:
   virtual void setup() override;
   virtual void loop() override;
   virtual void onReadyToOperate() override;
-  virtual bool onChange(float newDistance, float prevDistance) { return true; };
+  virtual bool onChange(float newDistance, float prevDistance) { return true; }
   static const int DEFAULT_MEASUREMENT_INTERVAL = 1;
   static const int DEFAULT_PUBLISH_INTERVAL = 5;
 
 public:
   explicit PingNode(const char *name,
+                    const char *type="RCW-0001",
                     const int triggerPin = DEFAULTPIN,
                     const int echoPin = DEFAULTPIN,
                     const int measurementInterval = DEFAULT_MEASUREMENT_INTERVAL,
                     const int publishInterval = DEFAULT_PUBLISH_INTERVAL);
 
   float getDistance() const { return _distance; }
+  int getPingTime() const { return _ping_us; }
   PingNode &setTemperature(float temperatureCelcius);
-  PingNode &setMicrosecondsToMetersFactor(float temperatureCelcius) { return setTemperature(temperatureCelcius); };
+  PingNode &setMicrosecondsToMetersFactor(float temperatureCelcius) { return setTemperature(temperatureCelcius); }
   PingNode &setMinimumChange(float minimumChange);
   PingNode &setMinimumDistance(float minimumDistance);
   PingNode &setMaximumDistance(float maximumDistance);
-  PingNode &setMicrosecondsToMeters(float microseconds2meter);
+  PingNode &setMicrosecondsToMeter(float microseconds2meter);
   PingNode &setChangeHandler(const ChangeHandler &changeHandler);
   virtual void send(bool changed);
 };

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -41,6 +41,7 @@ private:
   float _distance = NAN;
   int _ping_us = 0;
   float _lastDistance = 0;
+  float _lastPublishedDistance = 0;
   ChangeHandler _changeHandler = []() {};
 
   float getRawEchoTime();

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -41,7 +41,7 @@ private:
   float _distance = NAN;
   int _ping_us = 0;
   float _lastDistance = 0;
-  ChangeHandler _changeHandler = [](PingNode&) {};
+  ChangeHandler _changeHandler = []() {};
 
   float getRawEchoTime();
   bool signalChange(float distance, float lastDistance);
@@ -52,6 +52,7 @@ protected:
   virtual void setup() override;
   virtual void loop() override;
   virtual void onReadyToOperate() override;
+  virtual bool onChange(float newDistance, float prevDistance) { return true; };
   static const int DEFAULT_MEASUREMENT_INTERVAL = 1;
   static const int DEFAULT_PUBLISH_INTERVAL = 5;
 
@@ -64,9 +65,10 @@ public:
 
   float getDistance() const { return _distance; }
   PingNode &setTemperature(float temperatureCelcius);
+  PingNode &setMicrosecondsToMetersFactor(float temperatureCelcius) { return setTemperature(temperatureCelcius); };
   PingNode &setMinimumChange(float minimumChange);
   PingNode &setMinimumDistance(float minimumDistance);
   PingNode &setMaximumDistance(float maximumDistance);
-  PingNode &setMicrosecondsToMetersFactor(float microseconds2meter);
+  PingNode &setMicrosecondsToMeters(float microseconds2meter);
   PingNode &setChangeHandler(const ChangeHandler &changeHandler);
 };

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -18,13 +18,9 @@
 class PingNode : public SensorNode
 {
 public:
-  typedef std::function<void()> ChangeHandler;
+  typedef std::function<void(PingNode &)> ChangeHandler;
 
 private:
-  const float cMinDistance = 0.0;
-  const float cMaxDistance = 3.0;
-  const float cMinimumChange = 0.2;
-
   static const int MIN_INTERVAL = 1; // in seconds
   const char *cCaption = "• RCW-0001 sensor";
   const char *cIndent = "  ◦ ";
@@ -33,6 +29,9 @@ private:
   int _echoPin;
   float _microseconds2meter;
 
+  float _minChange = 0.2;
+  float _minDistance = 0.0;
+  float _maxDistance = 4.0;
   unsigned long _measurementInterval;
   unsigned long _lastMeasurement;
   unsigned long _publishInterval;
@@ -42,13 +41,12 @@ private:
   float _distance = NAN;
   int _ping_us = 0;
   float _lastDistance = 0;
-  ChangeHandler _changeHandler = []() {};
+  ChangeHandler _changeHandler = [](PingNode&) {};
 
   float getRawEchoTime();
-  void setMicrosecondsToMetersFactor(float temperatureCelcius);
   bool signalChange(float distance, float lastDistance);
   void printCaption();
-  void send();
+  void send(bool changed);
 
 protected:
   virtual void setup() override;
@@ -65,6 +63,10 @@ public:
                     const int publishInterval = DEFAULT_PUBLISH_INTERVAL);
 
   float getDistance() const { return _distance; }
-  void setTemperature(float temperatureCelcius) { setMicrosecondsToMetersFactor(temperatureCelcius); }
+  PingNode &setTemperature(float temperatureCelcius);
+  PingNode &setMinimumChange(float minimumChange);
+  PingNode &setMinimumDistance(float minimumDistance);
+  PingNode &setMaximumDistance(float maximumDistance);
+  PingNode &setMicrosecondsToMetersFactor(float microseconds2meter);
   PingNode &setChangeHandler(const ChangeHandler &changeHandler);
 };

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -67,7 +67,6 @@ public:
   float getDistance() const { return _distance; }
   int getPingTime() const { return _ping_us; }
   PingNode &setTemperature(float temperatureCelcius);
-  PingNode &setMicrosecondsToMetersFactor(float temperatureCelcius) { return setTemperature(temperatureCelcius); }
   PingNode &setMinimumChange(float minimumChange);
   PingNode &setMinimumDistance(float minimumDistance);
   PingNode &setMaximumDistance(float maximumDistance);

--- a/src/PingNode.hpp
+++ b/src/PingNode.hpp
@@ -47,7 +47,6 @@ private:
   float getRawEchoTime();
   bool signalChange(float distance, float lastDistance);
   void printCaption();
-  void send(bool changed);
 
 protected:
   virtual void setup() override;
@@ -72,4 +71,5 @@ public:
   PingNode &setMaximumDistance(float maximumDistance);
   PingNode &setMicrosecondsToMeters(float microseconds2meter);
   PingNode &setChangeHandler(const ChangeHandler &changeHandler);
+  virtual void send(bool changed);
 };


### PR DESCRIPTION
Changes:
- Change the constructor's parameters to accept id and name for the node
- Make MaxDistance, MinDistance, and MinChange configurable, and add the corresponding setter methods
- Rename setMicrosecondsToMetersFactor to `setTemperature`
- Remove the erroneous setMicrosecondsToMetersFactor()
- Implement a method `setMicrosecondsToMeter()` accepting an actual "microseconds_to_m" factor as the argument. This will allow setting the factor without using a temperature sensor. For example, if I know that my object is 20cm when fully opened, and I know the microseconds (reported by the node), I can call setMicrosecondsToMeter( us_at_20cm / 0.2 )

I deliberately changed the method's name from `setMicrosecondsToMetersFactor` to `setMicrosecondsToMeter` 

Code that calls setMicrosecondsToMetersFactor will need to rename it to setTemperature 

- Add a protected, virtual onChange() method that can be overridden by the descendent class.

- Modify the logic within the loop() - decouple the change notifications (changeHandler) from the publish interval, so that changeHandler gets called as soon as a change is detected, subject to measurement interval.

- Change the setXXX methods to return a reference to `this`, so that the setter method calls can be chained, e.g. 
```
node.setTemperature().setMinimumDistance().setChangeHandler();
```

